### PR TITLE
Placeholder rake scripts for enqueueing and working index jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem "elasticsearch", '~> 6.1.0'
 
 gem "whenever"
 
+# Unlike in most of our projects, this is used in production (to set the node type)
+gem 'dotenv-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -37,8 +40,6 @@ group :development, :test do
 
   # Records HTTP requests
   gem 'vcr'
-
-  gem 'dotenv-rails'
 
   gem 'whenever-test'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem "versionist"
 
 gem "elasticsearch", '~> 6.1.0'
 
+gem "whenever"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -37,6 +39,8 @@ group :development, :test do
   gem 'vcr'
 
   gem 'dotenv-rails'
+
+  gem 'whenever-test'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    chronic (0.10.2)
     concurrent-ruby (1.1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -198,6 +199,10 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
+    whenever-test (1.0.1)
+      whenever
     yard (0.9.14)
 
 PLATFORMS
@@ -220,6 +225,8 @@ DEPENDENCIES
   vcr
   versionist
   webmock
+  whenever
+  whenever-test
 
 RUBY VERSION
    ruby 2.5.0p0

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,8 +32,8 @@ module OpenSearch
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    def is_admin_node?
-      ENV['NODE_TYPE'] == 'admin'
+    def is_manager_node?
+      ENV['NODE_TYPE'] == 'manager'
     end
 
     def is_api_node?

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require "action_controller/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module SearchApi
+module OpenSearch
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
@@ -31,5 +31,17 @@ module SearchApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    def is_admin_node?
+      ENV['NODE_TYPE'] == 'admin'
+    end
+
+    def is_api_node?
+      ENV['NODE_TYPE'] == 'api'
+    end
+
+    def is_worker_node?
+      ENV['NODE_TYPE'] == 'worker'
+    end
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
 require_relative "application" unless defined? Rails # to test node type
 
-if ::Rails.application.is_admin_node?
+if ::Rails.application.is_manager_node?
   every 5.minutes do
     rake 'enqueue_index_jobs'
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 5.minutes do
+  rake 'enqueue_index_jobs'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,7 @@
-every 5.minutes do
-  rake 'enqueue_index_jobs'
+require_relative "application" unless defined? Rails # to test node type
+
+if ::Rails.application.is_admin_node?
+  every 5.minutes do
+    rake 'enqueue_index_jobs'
+  end
 end

--- a/install_app.sh
+++ b/install_app.sh
@@ -13,7 +13,7 @@ gem install --conservative bundler
 echo Installing gems
 bundle install --without development test
 
-echo Installing JS packages
-yarn install
+echo Updating crontab
+whenever --update-crontab
 
 echo Done!

--- a/install_app.sh
+++ b/install_app.sh
@@ -19,7 +19,10 @@ BUNDLER_VERSION=`grep -A 2 "BUNDLED WITH" Gemfile.lock | tail -1`
 gem install --conservative bundler -v $BUNDLER_VERSION
 
 echo Installing gems
+# After install do an rbenv rehash to make sure newly installed executables
+# have shims available
 bundle install --without development test
+rbenv rehash
 
 echo Updating crontab
 # Note that this update's the user crontab which lives in /var/spool and isn't

--- a/install_app.sh
+++ b/install_app.sh
@@ -8,12 +8,19 @@ echo Installing Ruby $ruby_version
 source /home/ubuntu/rbenv-init && rbenv install -s $ruby_version
 
 echo Installing bundler
-gem install --conservative bundler
+# Get specific version of bundler used in the Gemfile.lock
+BUNDLER_VERSION=`grep -A 2 "BUNDLED WITH" Gemfile.lock | tail -1`
+gem install --conservative bundler -v $BUNDLER_VERSION
 
 echo Installing gems
 bundle install --without development test
 
 echo Updating crontab
-whenever --update-crontab
+# Note that this update's the user crontab which lives in /var/spool and isn't
+# saved in an AWS AMI.  However, since our AWS launch configurations call this
+# script, the crontab will be set up again when the AMI is launched in an instance.
+whenever --set "job_template=sudo -H -i -u ubuntu bash -c '. ~/rbenv-init; :job' \
+               &cron_log=$PWD/log/whenever.log" \
+         --update-crontab
 
 echo Done!

--- a/install_app.sh
+++ b/install_app.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Exit with non-zero status if a simple command fails, even with piping
+# https://stackoverflow.com/a/4346420/1664216
+
+set -e
+set -o pipefail
+
 # Script to run on the deployed server when the code has been
 # updated (or on first deployment)
 

--- a/lib/tasks/enqueue_index_jobs.rake
+++ b/lib/tasks/enqueue_index_jobs.rake
@@ -1,0 +1,9 @@
+desc <<-DESC.strip_heredoc
+  Adds indexing jobs (creation and deletion of indexes) into an SQS queue and ensures
+  that workers are available to work them.
+DESC
+task enqueue_index_jobs: :environment do
+
+  Rails.logger.info { "Ran placeholder enqueue_index_jobs task!" }
+
+end

--- a/lib/tasks/work_index_job.rake
+++ b/lib/tasks/work_index_job.rake
@@ -1,0 +1,8 @@
+desc <<-DESC.strip_heredoc
+  Pulls an index job from an SQS queue and works it.
+DESC
+task work_index_job: :environment do
+
+  Rails.logger.info { "Ran placeholder work_index_job task!" }
+
+end

--- a/spec/lib/enqueue_index_jobs_spec.rb
+++ b/spec/lib/enqueue_index_jobs_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'enqueue_index_jobs', type: :rake do
+  include_context 'rake'
+
+  it "works as a placeholder" do
+    expect(Rails.logger).to receive(:info) do |&block|
+      expect(block.call).to match /Ran placeholder/
+    end
+    call
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,10 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# https://github.com/colszowka/simplecov/issues/369#issuecomment-313493152
+# Load rake tasks so they can be tested
+Rails.application.load_tasks unless defined?(Rake::Task) && Rake::Task.task_defined?('environment')
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -1,0 +1,13 @@
+# https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+# https://github.com/colszowka/simplecov/issues/369#issuecomment-313493152
+RSpec.shared_context "rake" do
+  let(:rake)      { Rake.application }
+  let(:task_name) { self.class.top_level_description }
+  subject(:task)  { rake[task_name] }
+
+  before          { task.reenable }
+
+  def call(*args)
+    task.invoke(*args)
+  end
+end

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'whenever schedule' do
+
+  # Testing rake tasks in the whenever schedule is easy, we just check that
+  # they are in the list.  When testing regular ruby calls, we want to run
+  # the scheduled runner jobs and see that the appropriate code is reached
+  # with the expected arguments.
+
+  let(:rake) { Rake.application }
+  let(:schedule) { Whenever::Test::Schedule.new(file: 'config/schedule.rb') }
+
+  it 'calls enqueue_index_jobs.rake' do
+    expect(scheduled_rake_task("enqueue_index_jobs")).not_to be_nil
+  end
+
+  def scheduled_rake_task(name)
+    schedule.jobs[:rake].select{|job| job[:task] == name}
+  end
+
+end

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -10,11 +10,15 @@ RSpec.describe 'whenever schedule' do
   let(:rake) { Rake.application }
   let(:schedule) { Whenever::Test::Schedule.new(file: 'config/schedule.rb') }
 
-  it 'calls enqueue_index_jobs.rake' do
-    expect(scheduled_rake_task("enqueue_index_jobs")).not_to be_nil
+  context "admin node" do
+    before { allow(Rails.application).to receive(:is_admin_node?) { true } }
+
+    it 'calls enqueue_index_jobs.rake' do
+      expect(scheduled_rake_tasks("enqueue_index_jobs").length).to eq 1
+    end
   end
 
-  def scheduled_rake_task(name)
+  def scheduled_rake_tasks(name)
     schedule.jobs[:rake].select{|job| job[:task] == name}
   end
 

--- a/spec/whenever_spec.rb
+++ b/spec/whenever_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'whenever schedule' do
   let(:rake) { Rake.application }
   let(:schedule) { Whenever::Test::Schedule.new(file: 'config/schedule.rb') }
 
-  context "admin node" do
-    before { allow(Rails.application).to receive(:is_admin_node?) { true } }
+  context "manager node" do
+    before { allow(Rails.application).to receive(:is_manager_node?) { true } }
 
     it 'calls enqueue_index_jobs.rake' do
       expect(scheduled_rake_tasks("enqueue_index_jobs").length).to eq 1


### PR DESCRIPTION
The deployment scripts will have mechanisms for calling two rake scripts, one to enqueue index jobs and another to work indexing jobs.  We will implement these scripts later, but so that we can get the deployment gears working together we need empty versions of the scripts to exist so we can call them.  The implementations in this PR just write a log entry so that we know they ran.