### PR TITLE
enable optional 'open-search' URL path prefix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem "whenever"
 # Unlike in most of our projects, this is used in production (to set the node type)
 gem 'dotenv-rails'
 
+gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "eb239c532941f"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/openstax/path_prefixer.git
+  revision: eb239c532941f61c4060f89dc29a9ace825aca55
+  ref: eb239c532941f
+  specs:
+    openstax_path_prefixer (0.0.1)
+      rails (>= 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -225,6 +233,7 @@ DEPENDENCIES
   elasticsearch (~> 6.1.0)
   listen (>= 3.0.5, < 3.2)
   openstax_healthcheck
+  openstax_path_prefixer!
   puma (~> 3.11)
   rails (~> 5.2.2)
   rspec-rails (~> 3.8)

--- a/config/initializers/openstax_path_prefixer.rb
+++ b/config/initializers/openstax_path_prefixer.rb
@@ -1,0 +1,3 @@
+OpenStax::PathPrefixer.configure do |config|
+  config.prefix = "open-search"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,22 +2,18 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   namespace :api do
-    scope 'book-search' do
+    api_version(
+      module: 'V0',
+      path: { value: 'v0' },
+      defaults: { format: :json },
+      default: true
+    ) do
 
-      api_version(
-        module: 'V0',
-        path: { value: 'v0' },
-        defaults: { format: :json },
-        default: true
-      ) do
+      get :search, to: 'search#search'
 
-        get :search, to: 'search#search'
+      get :temp_build_index, to: 'search#temp_build_index'
 
-        get :temp_build_index, to: 'search#temp_build_index'
-
-      end
     end
-
   end
 
 end

--- a/spec/requests/path_prefix_spec.rb
+++ b/spec/requests/path_prefix_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'path prefixes with "open-search" work', type: :request do
+
+  it "should route requests that have the prefix" do
+    expect_any_instance_of(Api::V0::SearchController).to receive(:search)
+    get("/open-search/api/v0/search")
+  end
+
+  it "should route requests that don't have the prefix" do
+    expect_any_instance_of(Api::V0::SearchController).to receive(:search)
+    get("/api/v0/search")
+  end
+
+end


### PR DESCRIPTION
This PR builds off of @KarinaMendez2's work on Accounts to add an `/accounts` path prefix.  I put her code into a new middleware gem (https://github.com/openstax/path_prefixer) and used it here to give an `/open-search` optional path prefix.  This will let this search code be used under a CloudFront distribution that shares a top-level domain across multiple properties.