### PR TITLE
Fix RexReleases spec on Travis

### DIFF
--- a/spec/lib/rex_releases_spec.rb
+++ b/spec/lib/rex_releases_spec.rb
@@ -7,12 +7,7 @@ RSpec.describe RexReleases, vcr: VCR_OPTS do
 
   let(:fake_bucket_name) { "spec-bucket-#{SecureRandom.hex(7)}" }
 
-  # This spec currently fails only on Travis with an error about missing AWS
-  # credentials.  The spec uses recorded HTTP interactions from VCR so why this
-  # is failing is puzzling.  Since this is prototype code that may or not be in
-  # the production implementation, we'll skip it for now so that our Travis runs
-  # can complete successfully.
-  xit 'reads the release IDs from S3' do
+  it 'reads the release IDs from S3' do
     stub_secrets
 
     TempAwsEnv.make do |env|


### PR DESCRIPTION
The RexReleases spec had been failing only on Travis, and so we disabled it a few weeks ago.  I had a thought about how to fix it -- basically to set dummy AWS secrets in the `ENV` even though they aren't needed since we are using recorded interactions.  I created this PR to test this out, but when I reenabled the spec it passed in Travis with no other modifications... so yay I guess :-)