### PR TITLE
add lograge for concise logging in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'dotenv-rails'
 
 gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "eb239c532941f"
 
+# More concise, one-liner logs (better for production)
+gem "lograge"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -178,6 +183,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -248,6 +255,7 @@ DEPENDENCIES
   faraday_middleware
   faraday_middleware-aws-sigv4
   listen (>= 3.0.5, < 3.2)
+  lograge
   openstax_healthcheck
   openstax_path_prefixer!
   patron

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,11 +68,21 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  # config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  config.lograge.enabled = true
+  config.log_tags = [ :remote_ip ]
+  config.lograge.base_controller_class = 'ActionController::API'
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w(controller action format id)
+    {
+      params: event.payload[:params].except(*exceptions)
+    }
+  end
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
Adds the lograge gem and production environment configuration to enable 1-line log messages, e.g.

```
[127.0.0.1] method=GET path=/api/v0/search format=json controller=Api::V0::SearchController action=search status=204 duration=0.11 view=0.00 params={"q"=>"\"test\""}
```

I copied the configuration we are currently using on Accounts.  I know of no good way to test this in a spec.

Here's a screenshot of this code logging in a production environment to Graylog:

![image](https://user-images.githubusercontent.com/1001691/55808922-3f9d8380-5aa2-11e9-801f-d85d8f106451.png)
