### PR TITLE
update openstax_path_prefixer for redirect and url helper support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "whenever"
 # Unlike in most of our projects, this is used in production (to set the node type)
 gem 'dotenv-rails'
 
-gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "eb239c532941f"
+gem "openstax_path_prefixer", github: "openstax/path_prefixer", ref: "b6d8f45d8"
 
 # More concise, one-liner logs (better for production)
 gem "lograge"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/openstax/path_prefixer.git
-  revision: eb239c532941f61c4060f89dc29a9ace825aca55
-  ref: eb239c532941f
+  revision: b6d8f45d8b9e702ce6b9b941a83f17a311aed599
+  ref: b6d8f45d8
   specs:
     openstax_path_prefixer (0.0.1)
       rails (>= 3.0)


### PR DESCRIPTION
open-search doesn't use redirects yet (or url/path helpers), but if they do later we'll want this updated version of the path prefixer gem which supports them.