### PR TITLE
make workers keep looking for termination

### DIFF
--- a/app/services/work_index_jobs.rb
+++ b/app/services/work_index_jobs.rb
@@ -38,10 +38,12 @@ class WorkIndexJobs
                        status: DoneIndexJob::STATUS_SUCCESSFUL,
                        es_stats: es_stats,
                        time_took: time_took)
-    rescue InvalidIndexingStrategy
+    rescue InvalidIndexingStrategy => ex
+      Raven.capture_exception(ex)
       enqueue_done_job(job: job,
                        status: DoneIndexJob::STATUS_INVALID_INDEXING_STRATEGY)
     rescue => ex
+      Raven.capture_exception(ex)
       enqueue_done_job(job: job,
                        status: DoneIndexJob::STATUS_OTHER_ERROR,
                        message: ex.message)

--- a/lib/tasks/work_index_jobs.rake
+++ b/lib/tasks/work_index_jobs.rake
@@ -2,7 +2,7 @@ desc <<-DESC.strip_heredoc
   Pulls an index job from an SQS queue and works it.
 DESC
 task work_index_jobs: :environment do
-  Rails.logger.info { "Starting work_index_jobs..." }
+  Rails.logger.info { "work_index_jobs: Started" }
 
   instance = OpenStax::Aws::AutoScalingInstance.me
   work_index_job = WorkIndexJobs.new
@@ -14,39 +14,27 @@ task work_index_jobs: :environment do
   while true do
     begin
       if instance.terminating_wait?
+        Rails.logger.info { "work_index_jobs: in Terminating:Wait, continuing to Termination"}
         instance.continue_to_termination(hook_name: "TerminationHook")
         break
       elsif work_index_job.definitely_out_of_work?
+        Rails.logger.info { "work_index_jobs: out of work, terminating"}
         instance.terminate(should_decrement_desired_capacity: true, continue_hook_name: "TerminationHook")
         break
       else
+        Rails.logger.info { "work_index_jobs: starting #call"}
         stats = work_index_job.call # reads from queue, works the job, writes to done queue
-        Rails.logger.info { "work_index_jobs #call w/ stats #{stats.to_s}" }
+        Rails.logger.info { "work_index_jobs: #call finished #{stats.to_s}" }
       end
     rescue Aws::AutoScaling::Errors::ScalingActivityInProgress => ee
-      Rails.logger.info { "Termination interrupted because scaling activity in progress.  Will retry in 30 seconds."}
+      Rails.logger.info { "work_index_jobs: Termination interrupted because scaling activity in progress.  Will retry in 30 seconds."}
       sleep(30)
     rescue => ee
       Raven.capture_exception(ee)
-      Rails.logger.info { "A #{ee.class.name} exception occurred.  Will continue working in 60 seconds."}
+      Rails.logger.info { "work_index_jobs: A #{ee.class.name} exception occurred.  Will continue working in 60 seconds."}
       sleep(60)
     end
   end
 
-  Rails.logger.info { "Ending work_index_jobs" }
-
-  # Things to do in this code:
-  #   It'd also be nice to have a failsafe that terminates this instance no
-  #   matter what happens after a defined period (e.g. which could come into play if
-  #   this rake task explodes and the "terminate and decrement ASG capacity" code
-  #   isn't reached).  We don't want to end up with a pile of workers just burning
-  #   money.  A way to do this would be to put a command in the worker's CloudFormation
-  #   launch configuration user data like the one in https://askubuntu.com/a/505938 :
-  #
-  #     sudo shutdown -P +60
-  #
-  #   If we wanted to be fancy, every iteration of this worker's main loop could cancel
-  #   this scheduled shutdown (`sudo shutdown -c`) and reset it for 60 minutes later when
-  #   the worker sees more work to do, just in case we have workers that are really
-  #   working for that long.
+  Rails.logger.info { "work_index_jobs: Ended" }
 end


### PR DESCRIPTION
If an exception happens when an instance tries to terminate, it will no longer be able to terminate (and it'll just loiter until its failsafe `shutdown` call kicks in 3h later).  This PR lets it continue trying to terminate.  

also, send exceptions off to Sentry as soon as we get them instead of waiting for them to be processed in the Done job.  We were not getting enough exception information out.