### PR TITLE
rescue errors when processing dead letter jobs

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,9 +1,9 @@
 # Load the Rails application.
 require_relative 'application'
 
+require 'prefix_logger'
 require 'rescue_from_unless_local'
 require 'os_elasticsearch_client'
 
 # Initialize the Rails application.
 Rails.application.initialize!
-

--- a/lib/prefix_logger.rb
+++ b/lib/prefix_logger.rb
@@ -1,0 +1,14 @@
+class Object
+
+  class << self
+    def prefix_logger(prefix, logger=Rails.logger)
+      %w(debug info error warn fatal).each do |level|
+        define_method "log_#{level}" do |*args, &block|
+          message = args.any? ? args[0] : block.call
+          logger.send(level.to_sym, "#{prefix}: #{message}")
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/prefix_logger_spec.rb
+++ b/spec/lib/prefix_logger_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "Prefix Logger" do
+
+  let(:klass) {
+    Class.new do
+      prefix_logger "Hiya"
+
+      def do_it_with_args
+        log_info "there"
+      end
+
+      def do_it_with_block
+        log_info { "there" }
+      end
+    end
+  }
+
+  it "logs with a prefix using args" do
+    expect(Rails.logger).to receive(:info).with "Hiya: there"
+    expect(klass.new.do_it_with_args)
+  end
+
+  it "logs with a prefix using block message" do
+    expect(Rails.logger).to receive(:info).with "Hiya: there"
+    expect(klass.new.do_it_with_block)
+  end
+
+end


### PR DESCRIPTION
* Rescue errors when processing dead letter jobs (just in case)
* Add a `logger_prefix` utility to prefix log messages with some string within a class