### PR TITLE
bogus rex releases

### DIFF
--- a/app/models/book_index_state.rb
+++ b/app/models/book_index_state.rb
@@ -11,6 +11,7 @@ class BookIndexState
     ACTIONS = [
       ACTION_CREATE  = 'enqueued_create',
       ACTION_CREATED = 'index_created',
+      ACTION_ERROR   = 'index_error',
       ACTION_DELETE_PENDING = "index_delete_pending"
     ]
 
@@ -48,6 +49,7 @@ class BookIndexState
   STATES = [
     STATE_CREATE_PENDING = "create pending",
     STATE_DELETE_PENDING = "delete pending",
+    STATE_HTTP_ERROR = "http error",
     STATE_CREATED = "created"
   ]
   VALID_INDEXING_STRATEGY_NAMES = %w(I1)
@@ -78,6 +80,12 @@ class BookIndexState
   def mark_created
     self.state = STATE_CREATED
     self.status_log << StatusLog.new(action: StatusLog::ACTION_CREATED)
+    save!
+  end
+
+  def mark_as_http_error
+    self.state = STATE_HTTP_ERROR
+    self.status_log << StatusLog.new(action: StatusLog::ACTION_ERROR)
     save!
   end
 

--- a/app/models/book_index_state.rb
+++ b/app/models/book_index_state.rb
@@ -9,10 +9,11 @@ class BookIndexState
 
   class StatusLog
     ACTIONS = [
-      ACTION_CREATE  = 'enqueued_create',
-      ACTION_CREATED = 'index_created',
-      ACTION_ERROR   = 'index_error',
-      ACTION_DELETE_PENDING = "index_delete_pending"
+      ACTION_CREATE  = 'enqueued create',
+      ACTION_CREATED = 'index created',
+      ACTION_INDEX_ERROR   = 'index error',
+      ACTION_HTTP_ERROR    = 'http error',
+      ACTION_DELETE_PENDING = "index delete pending"
     ]
 
     attr_reader :action, :at
@@ -85,7 +86,8 @@ class BookIndexState
 
   def mark_as_http_error
     self.state = STATE_HTTP_ERROR
-    self.status_log << StatusLog.new(action: StatusLog::ACTION_ERROR)
+    self.status_log << StatusLog.new(action: StatusLog::ACTION_HTTP_ERROR)
+    self.status_log << StatusLog.new(action: StatusLog::ACTION_INDEX_ERROR)
     save!
   end
 

--- a/app/services/books/search_strategies/s1/strategy.rb
+++ b/app/services/books/search_strategies/s1/strategy.rb
@@ -38,6 +38,8 @@ module Books::SearchStrategies::S1
         _source: %w(element_type element_id page_id page_position),
         highlight: {
           number_of_fragments: 20,
+          pre_tags: ["<strong>"],
+          post_tags: ["</strong>"],
           fields: {
             title: {},
             visible_content: {}

--- a/app/services/done_index_job.rb
+++ b/app/services/done_index_job.rb
@@ -69,11 +69,9 @@ class DoneIndexJob < BaseIndexJob
       ran_job.cleanup_when_done
     else
       if http_error?
-        Raven.capture_message("Openstax http error", :extra => inspect)
         book_index_state = find_associated_book_index_state
         book_index_state.mark_as_http_error
       else
-        Raven.capture_message("Job in Error Found in Done Queue", :extra => inspect)
         ran_job.remove_associated_book_index_state
       end
     end

--- a/spec/bindings/api/v0/search_result_spec.rb
+++ b/spec/bindings/api/v0/search_result_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Api::V0::Bindings::SearchResult do
             },
             highlight: {
               visible_content: [
-                "In 2006, Pluto was <em>demoted</em> to a ‘dwarf planet’ after scientists revised their definition of what constitutes"
+                "In 2006, Pluto was <strong>demoted</strong> to a ‘dwarf planet’ after scientists revised their definition of what constitutes"
               ]
             }
           }

--- a/spec/cassettes/BookIndexState/_create/creates_a_document_item_in_the_dynamo_db_table_with_correct_status.yml
+++ b/spec/cassettes/BookIndexState/_create/creates_a_document_item_in_the_dynamo_db_table_with_correct_status.yml
@@ -18,11 +18,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191210Z
+      - 20190710T205751Z
       X-Amz-Content-Sha256:
       - 560d274fe07649d0c2046c4fbc04178d9e9663e684bb1f2a1fe02b6ee31d301e
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -37,22 +37,22 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:11 GMT
+      - Wed, 10 Jul 2019 20:57:51 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
-      - '637'
+      - '638'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - I454476291I4F8002V77VT5AUFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 6ANP5F0VRMFS3N48MLCIU68PS3VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '206749840'
+      - '895546570'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.56218113131E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792271652E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:11 GMT
+  recorded_at: Wed, 10 Jul 2019 20:57:51 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -71,11 +71,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191211Z
+      - 20190710T205751Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -90,22 +90,22 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:11 GMT
+      - Wed, 10 Jul 2019 20:57:51 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
-      - '626'
+      - '627'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - IBVKPLAUC73463TO8FCB62KAAJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - ENFND131LS7K4NIN5BAB5EOI9BVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '2406593678'
+      - '3488410333'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.56218113131E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792271652E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:11 GMT
+  recorded_at: Wed, 10 Jul 2019 20:57:52 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -124,11 +124,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191231Z
+      - 20190710T205812Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -143,22 +143,22 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:32 GMT
+      - Wed, 10 Jul 2019 20:58:12 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
-      - '624'
+      - '625'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - CJS55PL1O7820I98G8KKVGM727VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - OM5OLC74QGK234P6GOSVSS9AT3VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1383451818'
+      - '3050850947'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.56218113131E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792271652E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:32 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:12 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -177,11 +177,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191232Z
+      - 20190710T205812Z
       X-Amz-Content-Sha256:
       - 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -196,7 +196,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:32 GMT
+      - Wed, 10 Jul 2019 20:58:12 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -204,21 +204,21 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - K9DAB8BPR26844JTMCPBCF7H6NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - SGILPM24AAFA3BUGUM6GQFOO2NVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '483464078'
     body:
       encoding: UTF-8
       string: '{"TableNames":["dev_indexing","jun10a-search-dynamo-db-IndexStateDynamoDBTable-1H3O9GD8QLWJD","test_indexing"]}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:33 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:13 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:12:33+00:00"},"updated_at":{"S":"2019-07-03T19:12:33+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
-        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-03T19:12:32.673Z\"}"}]}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T20:58:13+00:00"},"updated_at":{"S":"2019-07-10T20:58:13+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
+        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-10T20:58:12.671Z\"}"}]}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
     headers:
       Content-Type:
       - application/x-amz-json-1.0
@@ -231,11 +231,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191233Z
+      - 20190710T205813Z
       X-Amz-Content-Sha256:
-      - 1e7eb03cc9dd39d29c3dd2e554b9d7c6c4c6c04fa735d010c67d29a1e5f725fc
+      - a77f2f9375417f0b255789e1a86ce634d7ff1673de239e822ce5d55fbb62a877
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -250,7 +250,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:33 GMT
+      - Wed, 10 Jul 2019 20:58:13 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -258,14 +258,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - HAGOON8R6TBMPEHB0MI58PHEOJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 4CQRHMMQ3I3GBB19VRA2UKMF63VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:33 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:13 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -284,11 +284,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191233Z
+      - 20190710T205813Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -303,22 +303,22 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:34 GMT
+      - Wed, 10 Jul 2019 20:58:13 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
-      - '624'
+      - '625'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - I8P0JFB8G7K2H3IN0CRI51M9U7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - J6GTVA80SE9J1V4FTQTI9T0N7JVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1383451818'
+      - '3050850947'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.56218113131E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792271652E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:34 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:13 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -337,11 +337,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191234Z
+      - 20190710T205813Z
       X-Amz-Content-Sha256:
       - db7fbc1da807cbcfae110aba513db6c27cfa56d4e07a343db1e010469e0c43b0
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -356,7 +356,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:35 GMT
+      - Wed, 10 Jul 2019 20:58:14 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -364,14 +364,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 8F2G4IEF66QSBKTPIRORK81RD7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - V718R85SRLABCB000BQIUI92Q7VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '788233591'
     body:
       encoding: UTF-8
       string: '{"Count":1,"ScannedCount":1}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:35 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:14 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -390,11 +390,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191235Z
+      - 20190710T205814Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -409,7 +409,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:35 GMT
+      - Wed, 10 Jul 2019 20:58:14 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -417,14 +417,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - NLALBL4SF0NCKU3SPL7KDUB817VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5G9LV677U89BSUA3FQO2DR1L6FVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3367465758'
+      - '2935658063'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:36 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:14 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -443,11 +443,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191236Z
+      - 20190710T205814Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -462,7 +462,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:36 GMT
+      - Wed, 10 Jul 2019 20:58:14 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -470,14 +470,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - G61OE0FHGMT0P8BCVKL33UOJRFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - R8HFI1M9ORUVJ3IEOLMH2C1F7JVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1900618277'
+      - '386189172'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:36 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:14 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -496,11 +496,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191256Z
+      - 20190710T205834Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -515,7 +515,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:12:57 GMT
+      - Wed, 10 Jul 2019 20:58:35 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -523,14 +523,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 5OHJIR4376729JLDOG3RSV03Q3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - G0UBI5HN3PT0SDEOGQ06F1K3LFVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1900618277'
+      - '386189172'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:12:57 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:35 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -549,11 +549,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191317Z
+      - 20190710T205855Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -568,7 +568,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:13:17 GMT
+      - Wed, 10 Jul 2019 20:58:55 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -576,14 +576,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - J8QH44HTP126T5B78DR571UB43VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - M5205D393OV0ODRP9Q29G40H0VVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1900618277'
+      - '386189172'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:13:17 GMT
+  recorded_at: Wed, 10 Jul 2019 20:58:56 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -602,11 +602,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191337Z
+      - 20190710T205916Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -621,7 +621,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:13:38 GMT
+      - Wed, 10 Jul 2019 20:59:16 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -629,14 +629,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - AFQF7960P4PPT2EGJS1DCJC1QRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KODMN8FAKDCR3N4SPCNVJ8KCLVVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1900618277'
+      - '386189172'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:13:38 GMT
+  recorded_at: Wed, 10 Jul 2019 20:59:16 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -655,11 +655,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191358Z
+      - 20190710T205936Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -674,7 +674,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:13:58 GMT
+      - Wed, 10 Jul 2019 20:59:38 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -682,14 +682,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - ELTQQQ0NETUG5LDBNM96GDURMJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - J4N4TJ2QOPPDGOM3KRVGFV8OBNVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1900618277'
+      - '386189172'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"6f2a5b30-ec0d-4eab-8de8-3ad0e16b8dee","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d8bad8c5-6da3-4efa-bc3d-56299a78159a","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:13:58 GMT
+  recorded_at: Wed, 10 Jul 2019 20:59:38 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -708,11 +708,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191418Z
+      - 20190710T205958Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -727,7 +727,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:19 GMT
+      - Wed, 10 Jul 2019 20:59:58 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -735,7 +735,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - JK8QMM05U3JPTJO3M6739VTB5JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - DEQFJ3T72O0VS91VP3DKSPI833VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '504833711'
     body:
@@ -743,5 +743,5 @@ http_interactions:
       string: '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested
         resource not found: Table: test_indexing not found"}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:19 GMT
+  recorded_at: Wed, 10 Jul 2019 20:59:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BookIndexState/_live_book_indexings/finds_only_live_documents_not_the_deleting_ones.yml
+++ b/spec/cassettes/BookIndexState/_live_book_indexings/finds_only_live_documents_not_the_deleting_ones.yml
@@ -18,11 +18,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191419Z
+      - 20190710T205958Z
       X-Amz-Content-Sha256:
       - 560d274fe07649d0c2046c4fbc04178d9e9663e684bb1f2a1fe02b6ee31d301e
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -37,7 +37,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:19 GMT
+      - Wed, 10 Jul 2019 20:59:59 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -45,14 +45,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - QN2LOB9S6K91BBN8S7E28JB8CRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - T7SEE3VFS0RKV3TDQN7KGOHARRVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '4251279279'
+      - '80091162'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181259884E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792399241E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:19 GMT
+  recorded_at: Wed, 10 Jul 2019 20:59:59 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -71,11 +71,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191419Z
+      - 20190710T205959Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -90,7 +90,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:20 GMT
+      - Wed, 10 Jul 2019 20:59:59 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -98,14 +98,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - OSAB23JHMSQTKAFKT1L7KIBRB7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - JSERRPNSLKNBA64FPUK9BH6Q17VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '132727224'
+      - '4266264077'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181259884E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792399241E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:20 GMT
+  recorded_at: Wed, 10 Jul 2019 20:59:59 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -124,11 +124,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191440Z
+      - 20190710T210019Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -143,7 +143,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:40 GMT
+      - Wed, 10 Jul 2019 21:00:20 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -151,20 +151,20 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - TEDMJ4DS39J7EQIRPI04M3MNJJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - A8QFLN9PJHG8T17CF1MKABQBTNVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1119389093'
+      - '11953329'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181259884E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792399241E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:40 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:20 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:14:40+00:00"},"updated_at":{"S":"2019-07-03T19:14:40+00:00"},"book_version_id":{"S":"book@1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:00:20+00:00"},"updated_at":{"S":"2019-07-10T21:00:20+00:00"},"book_version_id":{"S":"book@1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
         pending"},"message":{"S":"message 1"}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
     headers:
       Content-Type:
@@ -178,11 +178,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191440Z
+      - 20190710T210020Z
       X-Amz-Content-Sha256:
-      - d90ac8c71431aaf1e0a17c816318c6d1ac3e9d3a084b4b2607d1e48e0ae298f8
+      - 38128d033aa2520f89366d3d77a2def699fe998336915df63b14bf94f6528327
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -197,7 +197,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:41 GMT
+      - Wed, 10 Jul 2019 21:00:20 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -205,20 +205,20 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - D1RU8OPIVA7P2US7TRC9I6CR2JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - V1OUH0095V45NHUQ5F5865LV9BVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:41 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:20 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:14:41+00:00"},"updated_at":{"S":"2019-07-03T19:14:41+00:00"},"book_version_id":{"S":"book@2"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:00:20+00:00"},"updated_at":{"S":"2019-07-10T21:00:20+00:00"},"book_version_id":{"S":"book@2"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
         pending"},"message":{"S":"message 2"}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
     headers:
       Content-Type:
@@ -232,11 +232,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191441Z
+      - 20190710T210020Z
       X-Amz-Content-Sha256:
-      - 48bba66458c4f997883abeb4ed726f9b77bfe7a223b572baf32b33e5d666065d
+      - e4d37eacd2a548d8b626782b2f74e7272719cad859f08dbbc1fae8900ff00d6b
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -251,7 +251,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:41 GMT
+      - Wed, 10 Jul 2019 21:00:20 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -259,20 +259,20 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - ASDIV6LGNIPDEIIJ6UR9DTD5HVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - OIP2D4HLCUNP8EER5BCTP70RKNVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:41 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:21 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:14:41+00:00"},"updated_at":{"S":"2019-07-03T19:14:41+00:00"},"book_version_id":{"S":"book@3"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"},"message":{"S":"message
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:00:21+00:00"},"updated_at":{"S":"2019-07-10T21:00:21+00:00"},"book_version_id":{"S":"book@3"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"},"message":{"S":"message
         3"}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
     headers:
       Content-Type:
@@ -286,11 +286,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191441Z
+      - 20190710T210021Z
       X-Amz-Content-Sha256:
-      - 26e9f51875a70bc05d60e8f2fda8c2ecabaac481e45f945a8ff1865bfb6007dc
+      - 8dd387e385d67d7a608c57f6da3a1e2a2f7a8486932bf4afa60cb945883b3e42
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -305,7 +305,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:42 GMT
+      - Wed, 10 Jul 2019 21:00:21 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -313,14 +313,68 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 218EQ9HV1DNAVRI46CE134RLIVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - F243R5EV1OLRCDULVID59P0LH3VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:42 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:21 GMT
+- request:
+    method: post
+    uri: https://dynamodb.us-east-2.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:00:21+00:00"},"updated_at":{"S":"2019-07-10T21:00:21+00:00"},"book_version_id":{"S":"book@4"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"http
+        error"},"message":{"S":"message 4"}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
+    headers:
+      Content-Type:
+      - application/x-amz-json-1.0
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
+      X-Amz-Target:
+      - DynamoDB_20120810.PutItem
+      Host:
+      - dynamodb.us-east-2.amazonaws.com
+      X-Amz-Date:
+      - 20190710T210021Z
+      X-Amz-Content-Sha256:
+      - 6dd6234bf16fb1f600c8a74d422618d3334c62dd7fcf26f73a8606edc1807193
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
+        Signature=<SignatureValue>
+      Content-Length:
+      - '346'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Server
+      Date:
+      - Wed, 10 Jul 2019 21:00:21 GMT
+      Content-Type:
+      - application/x-amz-json-1.0
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 4IQRT1A798LNO5MSECU29OUP5JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      X-Amz-Crc32:
+      - '2745614147'
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Wed, 10 Jul 2019 21:00:21 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -339,11 +393,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191442Z
+      - 20190710T210021Z
       X-Amz-Content-Sha256:
       - fa367b39423b3c7d2c1dc1c973fa658c3d085ee3123624f53579fdc2b8d8f0ce
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -358,27 +412,29 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:42 GMT
+      - Wed, 10 Jul 2019 21:00:22 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
-      - '703'
+      - '923'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - VTECVIFJQUQ641ASOHSIJDKPBBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - D7B36K9NV7T927RLGCE14QHBMVVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3262044167'
+      - '1776050363'
     body:
       encoding: UTF-8
-      string: '{"Count":3,"Items":[{"updated_at":{"S":"2019-07-03T19:14:41+00:00"},"message":{"S":"message
-        2"},"created_at":{"S":"2019-07-03T19:14:41+00:00"},"book_version_id":{"S":"book@2"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
-        pending"}},{"updated_at":{"S":"2019-07-03T19:14:40+00:00"},"message":{"S":"message
-        1"},"created_at":{"S":"2019-07-03T19:14:40+00:00"},"book_version_id":{"S":"book@1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
-        pending"}},{"updated_at":{"S":"2019-07-03T19:14:41+00:00"},"message":{"S":"message
-        3"},"created_at":{"S":"2019-07-03T19:14:41+00:00"},"book_version_id":{"S":"book@3"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"}}],"ScannedCount":3}'
+      string: '{"Count":4,"Items":[{"updated_at":{"S":"2019-07-10T21:00:20+00:00"},"message":{"S":"message
+        2"},"created_at":{"S":"2019-07-10T21:00:20+00:00"},"book_version_id":{"S":"book@2"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
+        pending"}},{"updated_at":{"S":"2019-07-10T21:00:20+00:00"},"message":{"S":"message
+        1"},"created_at":{"S":"2019-07-10T21:00:20+00:00"},"book_version_id":{"S":"book@1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
+        pending"}},{"updated_at":{"S":"2019-07-10T21:00:21+00:00"},"message":{"S":"message
+        3"},"created_at":{"S":"2019-07-10T21:00:21+00:00"},"book_version_id":{"S":"book@3"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"}},{"updated_at":{"S":"2019-07-10T21:00:21+00:00"},"message":{"S":"message
+        4"},"created_at":{"S":"2019-07-10T21:00:21+00:00"},"book_version_id":{"S":"book@4"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"http
+        error"}}],"ScannedCount":4}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:42 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:22 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -397,11 +453,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191442Z
+      - 20190710T210022Z
       X-Amz-Content-Sha256:
       - fa367b39423b3c7d2c1dc1c973fa658c3d085ee3123624f53579fdc2b8d8f0ce
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -416,27 +472,29 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:42 GMT
+      - Wed, 10 Jul 2019 21:00:22 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
-      - '703'
+      - '923'
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 78UKL85TF9SH80GBIG18VFEQMJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - E3MIT4654AI6F9SACP8510664RVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3262044167'
+      - '1776050363'
     body:
       encoding: UTF-8
-      string: '{"Count":3,"Items":[{"updated_at":{"S":"2019-07-03T19:14:41+00:00"},"message":{"S":"message
-        2"},"created_at":{"S":"2019-07-03T19:14:41+00:00"},"book_version_id":{"S":"book@2"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
-        pending"}},{"updated_at":{"S":"2019-07-03T19:14:40+00:00"},"message":{"S":"message
-        1"},"created_at":{"S":"2019-07-03T19:14:40+00:00"},"book_version_id":{"S":"book@1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
-        pending"}},{"updated_at":{"S":"2019-07-03T19:14:41+00:00"},"message":{"S":"message
-        3"},"created_at":{"S":"2019-07-03T19:14:41+00:00"},"book_version_id":{"S":"book@3"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"}}],"ScannedCount":3}'
+      string: '{"Count":4,"Items":[{"updated_at":{"S":"2019-07-10T21:00:20+00:00"},"message":{"S":"message
+        2"},"created_at":{"S":"2019-07-10T21:00:20+00:00"},"book_version_id":{"S":"book@2"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
+        pending"}},{"updated_at":{"S":"2019-07-10T21:00:20+00:00"},"message":{"S":"message
+        1"},"created_at":{"S":"2019-07-10T21:00:20+00:00"},"book_version_id":{"S":"book@1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
+        pending"}},{"updated_at":{"S":"2019-07-10T21:00:21+00:00"},"message":{"S":"message
+        3"},"created_at":{"S":"2019-07-10T21:00:21+00:00"},"book_version_id":{"S":"book@3"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"}},{"updated_at":{"S":"2019-07-10T21:00:21+00:00"},"message":{"S":"message
+        4"},"created_at":{"S":"2019-07-10T21:00:21+00:00"},"book_version_id":{"S":"book@4"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"http
+        error"}}],"ScannedCount":4}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:42 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:22 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -455,11 +513,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191442Z
+      - 20190710T210022Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -474,7 +532,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:43 GMT
+      - Wed, 10 Jul 2019 21:00:22 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -482,14 +540,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - DN9CFQEH6HOSS94G0LEEBRK827VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 87JBAD0NQS8RM8OLJN3J2OSDIBVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '2092559575'
+      - '74935345'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:43 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:22 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -508,11 +566,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191443Z
+      - 20190710T210022Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -527,7 +585,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:14:43 GMT
+      - Wed, 10 Jul 2019 21:00:23 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -535,14 +593,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - UO0SF1235NRG11SFQAHO0S1K5VVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CNGIKIIFRNAOP4L7IKED30ODIFVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3309813228'
+      - '3179887882'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:14:43 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:23 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -561,11 +619,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191503Z
+      - 20190710T210043Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -580,7 +638,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:15:04 GMT
+      - Wed, 10 Jul 2019 21:00:43 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -588,14 +646,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - G3GVAJ8TQUJS1ASVOCK7EK1RM7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 53OV0IGA2IQR2IF68K6I9GQ9IJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3309813228'
+      - '3179887882'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:15:04 GMT
+  recorded_at: Wed, 10 Jul 2019 21:00:43 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -614,11 +672,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191524Z
+      - 20190710T210103Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -633,7 +691,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:15:24 GMT
+      - Wed, 10 Jul 2019 21:01:04 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -641,14 +699,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 01OVHN5QMKP3M16BM259U0SFBBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - VOEQJFPDLFFGKG5A04OHSPM3TJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3309813228'
+      - '3179887882'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:15:24 GMT
+  recorded_at: Wed, 10 Jul 2019 21:01:04 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -667,11 +725,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191544Z
+      - 20190710T210124Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -686,7 +744,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:15:45 GMT
+      - Wed, 10 Jul 2019 21:01:24 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -694,14 +752,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 93GA5HTT6UV633L12KAGVGSEKBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - M1IFA3KBFAIR5DGPFA90BQ0VRRVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3309813228'
+      - '3179887882'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:15:45 GMT
+  recorded_at: Wed, 10 Jul 2019 21:01:24 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -720,11 +778,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191605Z
+      - 20190710T210144Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -739,7 +797,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:05 GMT
+      - Wed, 10 Jul 2019 21:01:45 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -747,14 +805,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - QCFLDJ1IE3VLJN11BDOI9BB173VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 17LGLCCGD6IPIUUNE3AOT0N0I7VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3309813228'
+      - '3179887882'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"afd7fc8b-c324-42de-a5f5-b99642305a14","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d6500f05-f2e8-4207-841d-01d58eac0c45","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:05 GMT
+  recorded_at: Wed, 10 Jul 2019 21:01:45 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -773,11 +831,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191625Z
+      - 20190710T210205Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -792,7 +850,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:26 GMT
+      - Wed, 10 Jul 2019 21:02:05 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -800,7 +858,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - RN60ELAE3OK5HIGI8S5QN9LTG3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 43HUC17UJQ07E953B58DT9B4VBVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '504833711'
     body:
@@ -808,5 +866,5 @@ http_interactions:
       string: '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested
         resource not found: Table: test_indexing not found"}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:26 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BookIndexState/_mark_created/updates_the_document_to_created_and_updates_the_status_log.yml
+++ b/spec/cassettes/BookIndexState/_mark_created/updates_the_document_to_created_and_updates_the_status_log.yml
@@ -18,11 +18,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192503Z
+      - 20190710T210411Z
       X-Amz-Content-Sha256:
       - 560d274fe07649d0c2046c4fbc04178d9e9663e684bb1f2a1fe02b6ee31d301e
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -37,7 +37,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:03 GMT
+      - Wed, 10 Jul 2019 21:04:11 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -45,14 +45,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - NSJ17BKNNVDK6V1JHOF0RN8MBJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - R42R2QAEC82K397OKG3JE87UAVVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3810095003'
+      - '112511473'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181903721E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792651811E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:03 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:11 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -71,11 +71,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192503Z
+      - 20190710T210411Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -90,7 +90,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:03 GMT
+      - Wed, 10 Jul 2019 21:04:11 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -98,14 +98,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - FSRM5FHHP4ID4L5N6E805OHEOVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - CMEA3O58PBLN60NLQ12TRF3F33VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '429224332'
+      - '4231583718'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181903721E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792651811E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:04 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:12 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -124,11 +124,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192524Z
+      - 20190710T210432Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -143,7 +143,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:24 GMT
+      - Wed, 10 Jul 2019 21:04:32 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -151,21 +151,21 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 5G7QRIFMQB8VOH0B9B81U1PM6FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PA8S233TEUD3OQMJO5H06S8D0BVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '2272962090'
+      - '2564082018'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181903721E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792651811E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:24 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:32 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:25:24+00:00"},"updated_at":{"S":"2019-07-03T19:25:24+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
-        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-03T19:25:24.882Z\"}"}]}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:04:32+00:00"},"updated_at":{"S":"2019-07-10T21:04:32+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
+        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-10T21:04:32.830Z\"}"}]}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
     headers:
       Content-Type:
       - application/x-amz-json-1.0
@@ -178,11 +178,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192524Z
+      - 20190710T210432Z
       X-Amz-Content-Sha256:
-      - 69c5d974dbe3759de278a7a5cda0becef1b2a82cde8f7cb3f1f189935e0b5a10
+      - 6543a58e94fa77cbadc975efa81a4c7c6766dd74f14852375b699719c76cd347
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -197,7 +197,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:25 GMT
+      - Wed, 10 Jul 2019 21:04:32 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -205,20 +205,20 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - A6KFFFVATL0SS9DVPKGDFCIGIRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 0MM5E4K838CQR2OAF6SU0BAOINVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:25 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:33 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:25:24+00:00"},"updated_at":{"S":"2019-07-03T19:25:25+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-03T19:25:24.882Z\"}"},{"S":"{\"action\":\"index_created\",\"at\":\"2019-07-03T19:25:25.408Z\"}"}]}},"Expected":{}}'
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:04:32+00:00"},"updated_at":{"S":"2019-07-10T21:04:33+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"created"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-10T21:04:32.830Z\"}"},{"S":"{\"action\":\"index_created\",\"at\":\"2019-07-10T21:04:33.125Z\"}"}]}},"Expected":{}}'
     headers:
       Content-Type:
       - application/x-amz-json-1.0
@@ -231,11 +231,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192525Z
+      - 20190710T210433Z
       X-Amz-Content-Sha256:
-      - c5878f81e8917bece3514d08f32bfe062f2e38f27ef86863e26133a9d6de1dc2
+      - 85a142701dcb4e044af37f56813293dac9771988aede07d9ebed34bc73f08a34
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -250,7 +250,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:25 GMT
+      - Wed, 10 Jul 2019 21:04:33 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -258,14 +258,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - KS7LMSN6UOU1DUAM3BCQCSD1VNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5QKROFKR23PHD5MEEOHAI0QODJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:25 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:33 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -284,11 +284,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192525Z
+      - 20190710T210433Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -303,7 +303,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:25 GMT
+      - Wed, 10 Jul 2019 21:04:33 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -311,14 +311,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - P7R8D0TRMV2PO1MI3O3T9UP4E7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - LDKQFS4PJ9G4H3B3C11O5CADGBVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1330121'
+      - '3677314552'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:26 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:33 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -337,11 +337,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192526Z
+      - 20190710T210433Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -356,7 +356,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:26 GMT
+      - Wed, 10 Jul 2019 21:04:34 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -364,14 +364,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - ICSDFETKJ2720017QTVQGQDIC3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 8IC9V9OK45Q54QUB84FUQQGBLJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3119127282'
+      - '1657867459'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:26 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:34 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -390,11 +390,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192546Z
+      - 20190710T210454Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -409,7 +409,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:46 GMT
+      - Wed, 10 Jul 2019 21:04:54 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -417,14 +417,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 6OH736QC41SFD9N5171JQQA8PNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - GPO19292QODHUTSSMO99T8FD93VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3119127282'
+      - '1657867459'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:47 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:54 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -443,11 +443,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192607Z
+      - 20190710T210514Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -462,7 +462,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:26:07 GMT
+      - Wed, 10 Jul 2019 21:05:15 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -470,14 +470,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 31EIASJ2T7AVHOVEPBJMMKTCMBVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 9O7EPD0JR3L2K4UBK9DEDB5SO3VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3119127282'
+      - '1657867459'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:26:07 GMT
+  recorded_at: Wed, 10 Jul 2019 21:05:15 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -496,11 +496,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192627Z
+      - 20190710T210535Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -515,7 +515,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:26:28 GMT
+      - Wed, 10 Jul 2019 21:05:35 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -523,14 +523,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - RBSNAV9GBEBEPUKVK0SKIC2O3NVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - BAR7SM5PNP3GM98RIJGN0BEQ7RVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3119127282'
+      - '1657867459'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:26:28 GMT
+  recorded_at: Wed, 10 Jul 2019 21:05:35 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -549,11 +549,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192648Z
+      - 20190710T210555Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -568,7 +568,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:26:48 GMT
+      - Wed, 10 Jul 2019 21:05:56 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -576,14 +576,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 8U4HHOFPFI8OAH0NCCDKD9PU7FVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 9QSUKRGP7GULU1HTPCDPD8EQ4FVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '3119127282'
+      - '1657867459'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"d5b1af8e-f2da-40cb-8cbf-da3d87408818","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"907d007f-7aff-423f-87d9-843dfa82f979","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:26:48 GMT
+  recorded_at: Wed, 10 Jul 2019 21:05:56 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -602,11 +602,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T192708Z
+      - 20190710T210616Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -621,7 +621,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:27:09 GMT
+      - Wed, 10 Jul 2019 21:06:16 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -629,7 +629,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - JOGM26H73UP3RIK4N1EU4BHRIVVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5KVOV30HGTTVPC9VKO9P7A56MVVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '504833711'
     body:
@@ -637,5 +637,5 @@ http_interactions:
       string: '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested
         resource not found: Table: test_indexing not found"}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:27:09 GMT
+  recorded_at: Wed, 10 Jul 2019 21:06:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/BookIndexState/_mark_queued_for_deletion/updates_the_document_to_be_deleted.yml
+++ b/spec/cassettes/BookIndexState/_mark_queued_for_deletion/updates_the_document_to_be_deleted.yml
@@ -18,11 +18,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191626Z
+      - 20190710T210206Z
       X-Amz-Content-Sha256:
       - 560d274fe07649d0c2046c4fbc04178d9e9663e684bb1f2a1fe02b6ee31d301e
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -37,7 +37,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:26 GMT
+      - Wed, 10 Jul 2019 21:02:06 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -45,14 +45,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 6OIHG2GLVHCTK3JL7PS079EB87VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - O6K8DJ8I4JP3PPH3QJJFDCK69FVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '2851963120'
+      - '2100381258'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181386753E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"TableDescription":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792526399E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:26 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:06 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -71,11 +71,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191626Z
+      - 20190710T210206Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -90,7 +90,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:26 GMT
+      - Wed, 10 Jul 2019 21:02:06 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -98,14 +98,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 9J3QKDK0RTP0UMKK3R946HI8TRVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - G45K48C3TJATS9DQSH17OSKB9BVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1399955175'
+      - '2277333085'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181386753E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792526399E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"CREATING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:27 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:06 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -124,11 +124,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191647Z
+      - 20190710T210226Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -143,7 +143,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:47 GMT
+      - Wed, 10 Jul 2019 21:02:27 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -151,21 +151,21 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - RV194FCSRGREV67UR9LIAPJ8UJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 6VMPISMG9FJB21CC6I267U0ROJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '2742028810'
+      - '1377369867'
     body:
       encoding: UTF-8
-      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562181386753E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
+      string: '{"Table":{"AttributeDefinitions":[{"AttributeName":"book_version_id","AttributeType":"S"},{"AttributeName":"indexing_strategy_name","AttributeType":"S"}],"CreationDateTime":1.562792526399E9,"ItemCount":0,"KeySchema":[{"AttributeName":"book_version_id","KeyType":"HASH"},{"AttributeName":"indexing_strategy_name","KeyType":"RANGE"}],"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"ACTIVE"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:47 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:27 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:16:47+00:00"},"updated_at":{"S":"2019-07-03T19:16:47+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
-        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-03T19:16:47.782Z\"}"}]}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:02:27+00:00"},"updated_at":{"S":"2019-07-10T21:02:27+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"create
+        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-10T21:02:27.405Z\"}"}]}},"Expected":{"book_version_id":{"Exists":false},"indexing_strategy_name":{"Exists":false}}}'
     headers:
       Content-Type:
       - application/x-amz-json-1.0
@@ -178,11 +178,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191647Z
+      - 20190710T210227Z
       X-Amz-Content-Sha256:
-      - 925772594ce39c0fb96b35a78af8e187aa185474320c26989f0907aa28d977e7
+      - 8266260d376e35f227ea8738b66929d9e568b7d6ed4fc5eec2eee0bc00e2e806
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -197,7 +197,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:47 GMT
+      - Wed, 10 Jul 2019 21:02:27 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -205,21 +205,21 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - U07CS6V21TJC89SG118DRO80P7VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5IF4MKAKODS2QLP37UK5R9LTU7VV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:48 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:27 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
     body:
       encoding: UTF-8
-      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-03T19:16:47+00:00"},"updated_at":{"S":"2019-07-03T19:16:48+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
-        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-03T19:16:47.782Z\"}"},{"S":"{\"action\":\"index_delete_pending\",\"at\":\"2019-07-03T19:16:48.084Z\"}"}]}},"Expected":{}}'
+      string: '{"TableName":"test_indexing","Item":{"created_at":{"S":"2019-07-10T21:02:27+00:00"},"updated_at":{"S":"2019-07-10T21:02:27+00:00"},"book_version_id":{"S":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1"},"indexing_strategy_name":{"S":"I1"},"state":{"S":"delete
+        pending"},"status_log":{"L":[{"S":"{\"action\":\"enqueued_create\",\"at\":\"2019-07-10T21:02:27.405Z\"}"},{"S":"{\"action\":\"index_delete_pending\",\"at\":\"2019-07-10T21:02:27.721Z\"}"}]}},"Expected":{}}'
     headers:
       Content-Type:
       - application/x-amz-json-1.0
@@ -232,11 +232,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191648Z
+      - 20190710T210227Z
       X-Amz-Content-Sha256:
-      - fa9f877c894a1dccbdf71d4db888d910253deb054b684744252cb90b46973564
+      - dd858f96125c87e39330ce1682adc418a32a06e3df3ad9fdca159d7cb94de15e
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -251,7 +251,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:48 GMT
+      - Wed, 10 Jul 2019 21:02:27 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -259,14 +259,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - P7SGJ6KQQVMC5C2KKCMVP81JAFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - M0VR17RS8R6N74LFKIHDD16GCJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '2745614147'
     body:
       encoding: UTF-8
       string: "{}"
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:48 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:28 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -285,11 +285,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191648Z
+      - 20190710T210228Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -304,7 +304,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:48 GMT
+      - Wed, 10 Jul 2019 21:02:28 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -312,14 +312,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - F2T2V5JFVNQ6ODDGSVLUUV0TNNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 0BE37CDT4NCDIE5TP0GAVP90GRVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '4103867206'
+      - '4205299264'
     body:
       encoding: UTF-8
-      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"TableDescription":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:48 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:28 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -338,11 +338,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191648Z
+      - 20190710T210228Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -357,7 +357,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:16:48 GMT
+      - Wed, 10 Jul 2019 21:02:28 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -365,14 +365,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 2DJ3L0OAPEL0H5G5D4IE1KDNR3VV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 5A4I6L17RRCNV03LR7P9QHP4RJVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1298291325'
+      - '1129944955'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:16:49 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:28 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -391,11 +391,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191709Z
+      - 20190710T210248Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -410,7 +410,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:17:09 GMT
+      - Wed, 10 Jul 2019 21:02:49 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -418,14 +418,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - U3HECT0RRI1SS17VA7969NLL7JVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - V602OLTQ1AD3R97OEUCCLBKT7BVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1298291325'
+      - '1129944955'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:17:09 GMT
+  recorded_at: Wed, 10 Jul 2019 21:02:49 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -444,11 +444,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191729Z
+      - 20190710T210309Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -463,7 +463,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:17:30 GMT
+      - Wed, 10 Jul 2019 21:03:09 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -471,14 +471,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - Q98UG27AR1AIL2DQCTUCUP48UNVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - DDJF5H52HNP0AEAAEPA3BLFM9JVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1298291325'
+      - '1129944955'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:17:30 GMT
+  recorded_at: Wed, 10 Jul 2019 21:03:09 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -497,11 +497,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191750Z
+      - 20190710T210329Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -516,7 +516,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:17:50 GMT
+      - Wed, 10 Jul 2019 21:03:30 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -524,14 +524,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - FCBDR0ERKGKP5IT0GLQ9G50SKFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - 37CJ5BFUCO4EB8GFCTT64CTOKVVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1298291325'
+      - '1129944955'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:17:50 GMT
+  recorded_at: Wed, 10 Jul 2019 21:03:30 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -550,11 +550,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191810Z
+      - 20190710T210350Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -569,7 +569,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:18:11 GMT
+      - Wed, 10 Jul 2019 21:03:50 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -577,14 +577,14 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - 6AU8AFGD2IVTOV60D2C4AOKNCJVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - PGKRNVAV5TO24849LF5G4G8RBRVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
-      - '1298291325'
+      - '1129944955'
     body:
       encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
+      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"bd1e2f83-fa19-440a-b822-2fe141ce0b01","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:18:11 GMT
+  recorded_at: Wed, 10 Jul 2019 21:03:50 GMT
 - request:
     method: post
     uri: https://dynamodb.us-east-2.amazonaws.com/
@@ -603,1018 +603,11 @@ http_interactions:
       Host:
       - dynamodb.us-east-2.amazonaws.com
       X-Amz-Date:
-      - 20190703T191831Z
+      - 20190710T210410Z
       X-Amz-Content-Sha256:
       - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:18:31 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - EDJGKJ449QH4Q1CQAG1OAFA9GBVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:18:31 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T191851Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:18:52 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - GLFSTUNTPQ69H7LJVA2OH51DHJVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:18:52 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T191912Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:19:13 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 9KQ3NIH7H0607RFVLIHVBKC8GJVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:19:13 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T191933Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:19:33 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - AJBKCG2PG9AU9QF9CB3BMG5PNJVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:19:33 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T191953Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:19:54 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 27GU0NO03J920O8REOB6RKHOG3VV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:19:54 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192014Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:20:14 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - H33U3DL9JEFSBA0K1CFNH4UNA3VV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:20:15 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192035Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:20:35 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - NPHVGULHACPD4FQ7MS1UJ61FONVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:20:35 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192055Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:20:55 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - Q9C4KGBUCD8M1B6NQHD6KBE703VV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:20:56 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192116Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:21:16 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 2DC0FDIHNC0RTTJJGFJ6UQAEL7VV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:21:16 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192136Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:21:37 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - J9O3F2T3OGJ1PEEVT6P1FA0POBVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:21:37 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192157Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:21:57 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 5G5ARI1LP19TTAI6FR06APVN7RVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:21:57 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192217Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:22:18 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - DN81O4ERIINM4JALK4EKNLS7S7VV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:22:18 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192238Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:22:38 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 472H28GS7NPEK2GS8C2JOMRDMNVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:22:39 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192259Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:22:59 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - L8OHFHA7PQ2G4UMTQJ6PF0JTPFVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:22:59 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192319Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:23:19 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 40PL5RHUAP2IV4F2SB5BKKIGBVVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:23:20 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192340Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:23:40 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - 0EMANBIKGDU5EU8PR28UVQU10VVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:23:40 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192400Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:24:01 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - ETUO80FNQ1SU3NDEBJ74UVID8BVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:24:01 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192421Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:24:21 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - K1JPTKEF700GK149UC8NAUPOENVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:24:22 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192442Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
-        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
-        Signature=<SignatureValue>
-      Content-Length:
-      - '29'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Server
-      Date:
-      - Wed, 03 Jul 2019 19:24:42 GMT
-      Content-Type:
-      - application/x-amz-json-1.0
-      Content-Length:
-      - '319'
-      Connection:
-      - keep-alive
-      X-Amzn-Requestid:
-      - RGNRQ1E4HERB23RR1AI1K3535NVV4KQNSO5AEMVJF66Q9ASUAAJG
-      X-Amz-Crc32:
-      - '1298291325'
-    body:
-      encoding: UTF-8
-      string: '{"Table":{"ItemCount":0,"ProvisionedThroughput":{"NumberOfDecreasesToday":0,"ReadCapacityUnits":2,"WriteCapacityUnits":2},"TableArn":"arn:aws:dynamodb:us-east-2:AWS_ACCOUNT_ID:table/test_indexing","TableId":"2afbe2d4-2430-4187-ab5c-8f7134576b38","TableName":"test_indexing","TableSizeBytes":0,"TableStatus":"DELETING"}}'
-    http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:24:42 GMT
-- request:
-    method: post
-    uri: https://dynamodb.us-east-2.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: '{"TableName":"test_indexing"}'
-    headers:
-      Content-Type:
-      - application/x-amz-json-1.0
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby3/3.44.1 ruby/2.5.0 x86_64-darwin16 aws-sdk-dynamodb/1.21.0
-      X-Amz-Target:
-      - DynamoDB_20120810.DescribeTable
-      Host:
-      - dynamodb.us-east-2.amazonaws.com
-      X-Amz-Date:
-      - 20190703T192502Z
-      X-Amz-Content-Sha256:
-      - b769faf39a6d0d44a0e395242dec7e6988e15b38ec5ad2735c8e20b1cb6c56c3
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190703/us-east-2/dynamodb/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20190710/us-east-2/dynamodb/aws4_request,
         SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target,
         Signature=<SignatureValue>
       Content-Length:
@@ -1629,7 +622,7 @@ http_interactions:
       Server:
       - Server
       Date:
-      - Wed, 03 Jul 2019 19:25:03 GMT
+      - Wed, 10 Jul 2019 21:04:11 GMT
       Content-Type:
       - application/x-amz-json-1.0
       Content-Length:
@@ -1637,7 +630,7 @@ http_interactions:
       Connection:
       - keep-alive
       X-Amzn-Requestid:
-      - NQPN4DHC3LUTCUC79BT7RVTVVFVV4KQNSO5AEMVJF66Q9ASUAAJG
+      - KE9ENLEJSEHH17CFJQD4OKPNURVV4KQNSO5AEMVJF66Q9ASUAAJG
       X-Amz-Crc32:
       - '504833711'
     body:
@@ -1645,5 +638,5 @@ http_interactions:
       string: '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested
         resource not found: Table: test_indexing not found"}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:25:03 GMT
+  recorded_at: Wed, 10 Jul 2019 21:04:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/api_v0_search_requests/_search/searches_.yml
+++ b/spec/cassettes/api_v0_search_requests/_search/searches_.yml
@@ -6,7 +6,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"size":150,"query":{"simple_query_string":{"fields":["title","visible_content"],"query":"\"Recall
-        that an atom\"","flags":"WHITESPACE|PHRASE","minimum_should_match":"100%","default_operator":"AND"}},"_source":["element_type","element_id","page_id","page_position"],"highlight":{"number_of_fragments":20,"fields":{"title":{},"visible_content":{}}}}'
+        that an atom\"","flags":"WHITESPACE|PHRASE","minimum_should_match":"100%","default_operator":"AND"}},"_source":["element_type","element_id","page_id","page_position"],"highlight":{"number_of_fragments":20,"pre_tags":["\u003cstrong\u003e"],"post_tags":["\u003c/strong\u003e"],"fields":{"title":{},"visible_content":{}}}}'
     headers:
       User-Agent:
       - Faraday v0.15.3
@@ -22,12 +22,12 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '575'
+      - '607'
     body:
       encoding: UTF-8
-      string: '{"took":29,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":1,"max_score":9.08708,"hits":[{"_index":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1_i1","_type":"page_element","_id":"gGyPs2sBamw8xuX-g3la","_score":9.08708,"_source":{"page_id":"2c60e072-7665-49b9-a2c9-2736b72b533c@8","element_id":"fs-id2113058","element_type":"paragraph","page_position":3},"highlight":{"visible_content":["<em>Recall</em>
-        <em>that</em> <em>an</em> <em>atom</em> typically has the same number of positively
-        charged protons and negatively charged"]}}]}}'
+      string: '{"took":36,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":1,"max_score":9.08708,"hits":[{"_index":"14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@15.1_i1","_type":"page_element","_id":"_2xOuWsBamw8xuX-QeKG","_score":9.08708,"_source":{"page_id":"2c60e072-7665-49b9-a2c9-2736b72b533c@8","element_id":"fs-id2113058","element_type":"paragraph","page_position":3},"highlight":{"visible_content":["<strong>Recall</strong>
+        <strong>that</strong> <strong>an</strong> <strong>atom</strong> typically
+        has the same number of positively charged protons and negatively charged"]}}]}}'
     http_version: 
-  recorded_at: Wed, 03 Jul 2019 19:27:09 GMT
+  recorded_at: Tue, 09 Jul 2019 21:35:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/models/book_index_state_spec.rb
+++ b/spec/models/book_index_state_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'vcr_helper'
 
 amazon_api_header_matcher = lambda do |request_1, request_2|
+  # puts "request1 x-amz-target #{request_1.headers["X-Amz-Target"]}, request2 x-amz-target #{request_2.headers["X-Amz-Target"]}"
   request_1.headers["X-Amz-Target"] == request_2.headers["X-Amz-Target"]
 end
 
@@ -33,6 +34,7 @@ RSpec.describe BookIndexState, vcr: VCR_OPTS.merge!({match_requests_on: [:method
     let(:book_id1) { 'book@1' }
     let(:book_id2) { 'book@2' }
     let(:book_id3) { 'book@3' }
+    let(:book_id4) { 'book@4' }
 
     def init_test
       book_index_state.new(state: BookIndexState::STATE_CREATE_PENDING,
@@ -47,6 +49,10 @@ RSpec.describe BookIndexState, vcr: VCR_OPTS.merge!({match_requests_on: [:method
                            book_version_id: book_id3,
                            indexing_strategy_name: indexing_strategy_name,
                            message: 'message 3').save!
+      book_index_state.new(state: BookIndexState::STATE_HTTP_ERROR,
+                           book_version_id: book_id4,
+                           indexing_strategy_name: indexing_strategy_name,
+                           message: 'message 4').save!
     end
 
     it 'finds only live documents, not the deleting ones' do
@@ -54,8 +60,8 @@ RSpec.describe BookIndexState, vcr: VCR_OPTS.merge!({match_requests_on: [:method
         env.create_dynamodb_table
         init_test
 
-        expect(BookIndexState.all.count).to eq 3
-        expect(BookIndexState.live.count).to eq 2
+        expect(BookIndexState.all.count).to eq 4
+        expect(BookIndexState.live.count).to eq 3
       end
     end
   end

--- a/spec/models/book_index_state_spec.rb
+++ b/spec/models/book_index_state_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 require 'vcr_helper'
 
 amazon_api_header_matcher = lambda do |request_1, request_2|
-  # puts "request1 x-amz-target #{request_1.headers["X-Amz-Target"]}, request2 x-amz-target #{request_2.headers["X-Amz-Target"]}"
   request_1.headers["X-Amz-Target"] == request_2.headers["X-Amz-Target"]
 end
 

--- a/spec/requests/api/v0/search_requests_spec.rb
+++ b/spec/requests/api/v0/search_requests_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'api v0 search requests', type: :request, api: :v0, vcr: VCR_OPTS
         element_type: "paragraph",
         page_position: 3
       )
-      expect(json[:hits][:hits][0][:highlight][:visible_content][0]).to start_with "<em>Recall</em>"
+      expect(json[:hits][:hits][0][:highlight][:visible_content][0]).to start_with "<strong>Recall</strong>"
     end
 
     context "client errors" do

--- a/spec/services/done_index_job_spec.rb
+++ b/spec/services/done_index_job_spec.rb
@@ -30,13 +30,26 @@ RSpec.describe DoneIndexJob do
     end
 
     context 'when not successful' do
-      let(:status) { "failed" }
+      context 'http error' do
+        let(:status) { described_class::STATUS_HTTP_ERROR }
 
-      it 'sends a message to Raven and removes the associated book index state' do
-        expect(Raven).to receive(:capture_message)
-        expect_any_instance_of(CreateIndexJob).to receive(:remove_associated_book_index_state)
+        it 'sends a message to Raven and sends a mark http error to book index state' do
+          expect(Raven).to receive(:capture_message)
+          expect(book_index_state).to receive(:mark_as_http_error)
 
-        done_index_job.call
+          done_index_job.call
+        end
+      end
+
+      context 'other job error' do
+        let(:status) { described_class::STATUS_OTHER_ERROR }
+
+        it 'sends a message to Raven and removes the associated book index state' do
+          expect(Raven).to receive(:capture_message)
+          expect_any_instance_of(CreateIndexJob).to receive(:remove_associated_book_index_state)
+
+          done_index_job.call
+        end
       end
     end
   end

--- a/spec/services/done_index_job_spec.rb
+++ b/spec/services/done_index_job_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe DoneIndexJob do
         let(:status) { described_class::STATUS_HTTP_ERROR }
 
         it 'sends a message to Raven and sends a mark http error to book index state' do
-          expect(Raven).to receive(:capture_message)
           expect(book_index_state).to receive(:mark_as_http_error)
 
           done_index_job.call
@@ -45,7 +44,6 @@ RSpec.describe DoneIndexJob do
         let(:status) { described_class::STATUS_OTHER_ERROR }
 
         it 'sends a message to Raven and removes the associated book index state' do
-          expect(Raven).to receive(:capture_message)
           expect_any_instance_of(CreateIndexJob).to receive(:remove_associated_book_index_state)
 
           done_index_job.call


### PR DESCRIPTION
Change the work index jobs service to handle cxn book 404s by creating a new done status for this error and processing different in the monitor service.   When a http 404 error is received, keep the book index state around so that it can be fixed (not re-indexed or deleted).  

Also, add pre_ and post_tags to change the highlighting markup returned by elasticsearch. 

https://app.zenhub.com/workspaces/openstax-unified-5b71aabe3815ff014b102258/issues/openstax/unified/318