### PR TITLE
Make sure 500s get to sentry even when rescuing exceptions

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -2,7 +2,7 @@ class Api::V0::BaseController < ApplicationController
   include Swagger::Blocks
   include OpenStax::Swagger::Bind
 
-  rescue_from_unless_local StandardError do |exception|
+  rescue_from_unless_local StandardError, send_to_sentry: true do |exception|
     render json: binding_error(status_code: 500, messages: [exception.message]), status: 500
   end
 


### PR DESCRIPTION
Previously we were rescuing 500s in production and not sending them to sentry.  Oops.