### PR TITLE
1468 Add lowercase filter

### DIFF
--- a/app/services/books/indexing_strategies/i1/strategy.rb
+++ b/app/services/books/indexing_strategies/i1/strategy.rb
@@ -61,6 +61,9 @@ module Books::IndexingStrategies::I1
                 tokenizer: "standard",
                 char_filter: [
                   "quotes"
+                ],
+                filter: [
+                  "lowercase"
                 ]
               }
             },


### PR DESCRIPTION
for: https://github.com/openstax/unified/issues/1468
It seems that I've missed a part of [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html) that is saying we should add a lowercase filter if we customize the analyzer:
> If you need to customize the standard analyzer beyond the configuration parameters then you need to recreate it as a custom analyzer and modify it, usually by adding token filters. This would recreate the built-in standard analyzer and you can use it as a starting point: