### PR TITLE
fix page archive url for github books

### DIFF
--- a/lib/patches/openstax_cnx.rb
+++ b/lib/patches/openstax_cnx.rb
@@ -37,7 +37,7 @@ module OpenStax::Cnx::V1
 
   class Page
     def id_without_version
-      id.gsub(/@[\d\.]+$/,'')
+      id.gsub(/@[\d\.]*$/,'')
     end
 
     def url


### PR DESCRIPTION
github books have page ids that end in an `@` with no version, like 
```
      {
        "id": "810e10c5-2e6b-47c1-aa36-a2645f3af52e@",
        "title": "<span data-type=\"\" itemprop=\"\" class=\"os-text\">Introduction</span>",
        "slug": "1-introduction"
      }
```