### PR TITLE
Load golden-ami default env variables

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,4 +49,4 @@ module OpenSearch
 end
 
 # Load system-wide env vars, will be set on EC2 instances, ignored otherwise
-Dotenv.load('/etc/.env')
+Dotenv.load('/etc/.env', '/etc/default/openstax')

--- a/lib/tasks/install_secrets.rake
+++ b/lib/tasks/install_secrets.rake
@@ -7,7 +7,7 @@ DESC
 task :install_secrets, [] do
   # Load the system-wide and local env vars here since the Rails application isn't loaded
   # for this rake task
-  Dotenv.load('/etc/.env', '.env')
+  Dotenv.load('.env', '/etc/.env', '/etc/default/openstax')
 
   # Secrets live in the AWS Parameter Store under a /env_name/parameter_namespace/
   # hierarchy.  Several environment variables are set by the AWS cloudformation scripts.


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1788
Dotenv is weird in that the file loaded first wins