### PR TITLE
Validate ES responses using updated swagger-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'nokogiri'
 
 gem 'openstax_cnx', github: 'openstax/cnx-ruby', ref: '480b4285e'
 
-gem "openstax_swagger", github: 'openstax/swagger-rails', ref: 'abf8508'
+gem "openstax_swagger", github: 'openstax/swagger-rails', ref: 'c88e569'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'nokogiri'
 
 gem 'openstax_cnx', github: 'openstax/cnx-ruby', ref: '480b4285e'
 
-gem "openstax_swagger", github: 'openstax/swagger-rails', ref: '0ad77d306d2'
+gem "openstax_swagger", github: 'openstax/swagger-rails', ref: 'abf8508'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,10 +32,10 @@ GIT
 
 GIT
   remote: https://github.com/openstax/swagger-rails.git
-  revision: abf8508de50d25c4beb265288290dc770952629a
-  ref: abf8508
+  revision: c88e569861378fa858e98da55eefe6da31b121c2
+  ref: c88e569
   specs:
-    openstax_swagger (0.1.0)
+    openstax_swagger (1.0.0)
       oj
       oj_mimic_json
       rails (>= 5.2.3, < 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,13 +32,13 @@ GIT
 
 GIT
   remote: https://github.com/openstax/swagger-rails.git
-  revision: 0ad77d306d24e220fb4703f4a9f02e219493bc02
-  ref: 0ad77d306d2
+  revision: abf8508de50d25c4beb265288290dc770952629a
+  ref: abf8508
   specs:
     openstax_swagger (0.1.0)
       oj
       oj_mimic_json
-      rails (~> 5.2.3)
+      rails (>= 5.2.3, < 7.0)
       swagger-blocks
 
 GEM
@@ -210,7 +210,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     null-logger (0.1.5)
-    oj (3.7.12)
+    oj (3.13.21)
     oj_mimic_json (1.0.1)
     openstax_healthcheck (0.0.3)
       rails (>= 3.0)
@@ -305,7 +305,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    swagger-blocks (2.0.2)
+    swagger-blocks (3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     typhoeus (1.3.1)
@@ -378,4 +378,4 @@ RUBY VERSION
    ruby 2.6.5
 
 BUNDLED WITH
-   2.1.4
+   2.3.7


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/360
Requires https://github.com/openstax/swagger-rails/pull/11 and we should probably merge that one and release a new version before merging this one