### PR TITLE
Fixed the character filter

### DIFF
--- a/app/services/books/indexing_strategies/i1/strategy.rb
+++ b/app/services/books/indexing_strategies/i1/strategy.rb
@@ -78,10 +78,9 @@ module Books::IndexingStrategies::I1
           },
           char_filter: {
             quotes: {
-              mappings: [
-                "’=>'",
-              ],
-              type: "mapping"
+              type: "pattern_replace",
+              pattern: "’",
+              replacement: "'"
             }
           }
         }


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1484

For some reason the current char_filter causes a bizarre error where the AWS signature fails on the index create request. Maybe something in there really doesn't like the `=>` but I couldn't find info about this.
However, the pattern_replace type seems equivalent and doesn't cause this issue.