### PR TITLE
Fixed index deletion triggering when it shouldn't

### DIFF
--- a/app/services/enqueue_index_jobs.rb
+++ b/app/services/enqueue_index_jobs.rb
@@ -23,7 +23,7 @@ class EnqueueIndexJobs
       end
     end
 
-    _, unneeded_book_indexings = index_states.partition(&:in_demand)
+    unneeded_book_indexings = index_states.reject(&:in_demand)
 
     unneeded_book_indexings.each do |unneeded_book_indexing|
       enqueue_delete_index_job(unneeded_book_indexing)
@@ -44,7 +44,7 @@ class EnqueueIndexJobs
   end
 
   def index_states
-    @index_states ||= BookIndexState.live
+    @index_states ||= BookIndexState.live.to_a
   end
 
   def find_book_indexing(book_id, indexing_strategy_name)


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1484

It's unclear why this bug did not affect elasticsearch.

in_demand was being set here: https://github.com/openstax/open-search/pull/110/files#diff-5482cda0b16b7ea9943dc675c7d6f64bc22453f5ea90444f6dc4cd7a1817c118R19

However, because index_states is a lazy loader, this change was not being propagated to it when it was accessed here: https://github.com/openstax/open-search/pull/110/files#diff-5482cda0b16b7ea9943dc675c7d6f64bc22453f5ea90444f6dc4cd7a1817c118R26

So all the indices were being deleted right after creation.