### PR TITLE
DISCO-104 Use multi_match instead of simple_query_string

### DIFF
--- a/app/services/books/indexing_strategies/i1/strategy.rb
+++ b/app/services/books/indexing_strategies/i1/strategy.rb
@@ -94,9 +94,9 @@ module Books::IndexingStrategies::I1
               type: 'stemmer',
               language: 'possessive_english'
             },
-            light_english_stemmer: {
+            plural_english_stemmer: {
               type: 'stemmer',
-              language: 'light_english'
+              language: 'plural_english'
             },
             english_index_common: common_words.merge({
               type: 'common_grams'
@@ -112,7 +112,7 @@ module Books::IndexingStrategies::I1
               filter: [
                 'english_possessive_stemmer',
                 'lowercase',
-                'light_english_stemmer',
+                'plural_english_stemmer',
                 'asciifolding',
                 'english_index_common'
               ]
@@ -122,7 +122,7 @@ module Books::IndexingStrategies::I1
               filter: [
                 'english_possessive_stemmer',
                 'lowercase',
-                'light_english_stemmer',
+                'plural_english_stemmer',
                 'asciifolding',
                 'english_search_common'
               ]
@@ -145,9 +145,9 @@ module Books::IndexingStrategies::I1
             'quotes'
           ],
           filter: {
-            light_spanish_stemmer: {
+            spanish_stemmer: {
               type: 'stemmer',
-              language: 'light_spanish'
+              language: 'spanish'
             },
             spanish_index_common: common_words.merge({
               type: 'common_grams'
@@ -162,7 +162,7 @@ module Books::IndexingStrategies::I1
               tokenizer: 'standard',
               filter: [
                 'lowercase',
-                'light_spanish_stemmer',
+                'spanish_stemmer',
                 'spanish_index_common'
               ]
             },
@@ -170,7 +170,7 @@ module Books::IndexingStrategies::I1
               tokenizer: 'standard',
               filter: [
                 'lowercase',
-                'light_spanish_stemmer',
+                'spanish_stemmer',
                 'spanish_search_common'
               ]
             }

--- a/app/services/books/search_strategies/s1/strategy.rb
+++ b/app/services/books/search_strategies/s1/strategy.rb
@@ -24,42 +24,17 @@ module Books::SearchStrategies::S1
 
     protected
 
-    def fuzzify(query_string)
-      # 1. Remove ~ and optional suffix from query (to prevent users setting their own fuzziness)
-      # 2. Convert smart quotes to normal quotes
-      # 3. Split into array of unquoted words, quoted phrases and balanced parentheses
-      #    Mismatched quotes are ignored
-      # 4. Add fuzziness to unquoted words only
-      # 5. Join array back into a string with spaces
-      #
-      # Fuzziness values replicate the AUTO fuzziness of other OpenSearch query types
-      # simple_query_string doesn't seem to support AUTO fuzziness
-      #
-      # Note: For whatever reason the outer group in the scan needs to be named
-      #       or it won't work, even though the name itself is irrelevant
-      query_string.gsub(/~[^\s"]*/, '').gsub(/“|”/, '"')
-                  .scan(/[^\s"()—–-]+|"[^"]*"|[()]/)
-                  .map do |str|
-        next str if str.start_with?('"', '(') || str.end_with?(')')|| str.length <= 2
-
-        fuzziness = str.length <= 5 ? 1 : 2
-        "#{str}~#{fuzziness}"
-      end.join(' ')
-    end
-
     def search_body(query_string)
       # query_string = single_quotes_to_double(query_string)
 
       {
         size: MAX_SEARCH_RESULTS,
         query: {
-          simple_query_string: {
+          multi_match: {
             fields: %w(title contextTitle visible_content),
-            query: fuzzify(query_string),
-            flags: "FUZZY|PHRASE|WHITESPACE",
-            minimum_should_match: "100%",
-            default_operator: "AND",
-            fuzzy_prefix_length: 3
+            operator: 'AND',
+            prefix_length: 3,
+            query: query_string
           }
         },
         track_total_hits: !!@options[:track_total_hits],

--- a/app/services/books/search_strategies/s1/strategy.rb
+++ b/app/services/books/search_strategies/s1/strategy.rb
@@ -38,8 +38,8 @@ module Books::SearchStrategies::S1
       # Note: For whatever reason the outer group in the scan needs to be named
       #       or it won't work, even though the name itself is irrelevant
       query_string.gsub(/~[^\s"]*/, '').gsub(/“|”/, '"')
-                  .scan(/(?<all>[^\s"()—–-]+|"[^"]*"|(?<paren>\((?>[^)(]+|\g<paren>)*\)))/)
-                  .map(&:first).map do |str|
+                  .scan(/[^\s"()—–-]+|"[^"]*"|[()]/)
+                  .map do |str|
         next str if str.start_with?('"', '(') || str.end_with?(')')|| str.length <= 2
 
         fuzziness = str.length <= 5 ? 1 : 2

--- a/app/services/books/search_strategies/s1/strategy.rb
+++ b/app/services/books/search_strategies/s1/strategy.rb
@@ -32,6 +32,7 @@ module Books::SearchStrategies::S1
         query: {
           multi_match: {
             fields: %w(title contextTitle visible_content),
+            fuzziness: 'AUTO',
             operator: 'AND',
             prefix_length: 3,
             query: query_string

--- a/spec/services/books/search_strategies/s1/strategy_spec.rb
+++ b/spec/services/books/search_strategies/s1/strategy_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe Books::SearchStrategies::S1::Strategy , type: :request, api: :v0,
 
     it 'applies fuzzy modifiers to unquoted words outside of parentheses only' do
       expect(search_strategy.send(
-        :fuzzify, 'a humongous word "in quotes" (and parentheses) sometimes(without)"spaces"'
-      )).to eq 'a humongous~2 word~1 "in quotes" (and parentheses) sometimes~2 (without) "spaces"'
+        :fuzzify, 'a humongous word "in quotes" (and parentheses) sometimes"(without)"("spaces")'
+      )).to eq 'a humongous~2 word~1 "in quotes" (and parentheses) sometimes~2 "(without)" ("spaces")'
     end
   end
 end

--- a/spec/services/books/search_strategies/s1/strategy_spec.rb
+++ b/spec/services/books/search_strategies/s1/strategy_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Books::SearchStrategies::S1::Strategy , type: :request, api: :v0,
     it 'applies fuzzy modifiers to unquoted words outside of parentheses only' do
       expect(search_strategy.send(
         :fuzzify, 'a humongous word "in quotes" (and parentheses) sometimes"(without)"("spaces")'
-      )).to eq 'a humongous~2 word~1 "in quotes" (and parentheses) sometimes~2 "(without)" ("spaces")'
+      )).to eq 'a humongous~2 word~1 "in quotes" ( and~1 parentheses~2 ) sometimes~2 "(without)" ( "spaces" )'
     end
   end
 end

--- a/spec/services/books/search_strategies/s1/strategy_spec.rb
+++ b/spec/services/books/search_strategies/s1/strategy_spec.rb
@@ -115,4 +115,14 @@ RSpec.describe Books::SearchStrategies::S1::Strategy , type: :request, api: :v0,
       expect((result["hits"]["hits"].select{|hit| hit['_index'].include?('8d50a0af')}).present?).to be_truthy
     end
   end
+
+  context 'fuzzify' do
+    let(:index_names) { [index_name] }
+
+    it 'applies fuzzy modifiers to unquoted words outside of parentheses only' do
+      expect(search_strategy.send(
+        :fuzzify, 'a humongous word "in quotes" (and parentheses) sometimes(without)"spaces"'
+      )).to eq 'a humongous~2 word~1 "in quotes" (and parentheses) sometimes~2 (without) "spaces"'
+    end
+  end
 end

--- a/spec/services/books/search_strategies/s1/strategy_spec.rb
+++ b/spec/services/books/search_strategies/s1/strategy_spec.rb
@@ -115,14 +115,4 @@ RSpec.describe Books::SearchStrategies::S1::Strategy , type: :request, api: :v0,
       expect((result["hits"]["hits"].select{|hit| hit['_index'].include?('8d50a0af')}).present?).to be_truthy
     end
   end
-
-  context 'fuzzify' do
-    let(:index_names) { [index_name] }
-
-    it 'applies fuzzy modifiers to unquoted words outside of parentheses only' do
-      expect(search_strategy.send(
-        :fuzzify, 'a humongous word "in quotes" (and parentheses) sometimes"(without)"("spaces")'
-      )).to eq 'a humongous~2 word~1 "in quotes" ( and~1 parentheses~2 ) sometimes~2 "(without)" ( "spaces" )'
-    end
-  end
 end


### PR DESCRIPTION
Per Erika's decision, I'm changing this PR to make search use multi_match instead of simple_query_string, which removes some user control over the query but should give us both stemming and fuzziness.