### PR TITLE
DISCO-255 Only apply fuzziness to words that are 5 letters or longer

### DIFF
--- a/app/services/books/search_strategies/s1/strategy.rb
+++ b/app/services/books/search_strategies/s1/strategy.rb
@@ -32,7 +32,7 @@ module Books::SearchStrategies::S1
         query: {
           multi_match: {
             fields: %w(title contextTitle visible_content),
-            fuzziness: 'AUTO',
+            fuzziness: 'AUTO:5,6',
             operator: 'AND',
             prefix_length: 3,
             query: query_string


### PR DESCRIPTION
Furthermore, we still require that the first 3 characters match exactly.

Deploying to https://github.com/openstax/unified/issues/2830 to test