### PR TITLE
Downgrade dotenv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'opensearch-aws-sigv4'
 gem "whenever"
 
 # Unlike in most of our projects, this is used in production (to set the node type)
-gem 'dotenv-rails'
+gem 'dotenv-rails', '3.1.4'
 
 gem "openstax_path_prefixer", github: "openstax/path_prefixer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,9 +154,9 @@ GEM
     crass (1.0.6)
     date (3.4.1)
     diff-lcs (1.6.2)
-    dotenv (3.1.8)
-    dotenv-rails (3.1.8)
-      dotenv (= 3.1.8)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
       railties (>= 6.1)
     dynamoid (3.12.1)
       activemodel (>= 4)
@@ -404,7 +404,7 @@ DEPENDENCIES
   bootsnap
   byebug
   concurrent-ruby (= 1.3.4)
-  dotenv-rails
+  dotenv-rails (= 3.1.4)
   dynamoid
   listen
   lograge


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1400

Dotenv 3.1.5+ fails when an empty variable is present in the .env file, like `export AUTO_SCALING_GROUP_NAME=`